### PR TITLE
Add sanitized senior-engineer-note-maker skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Reusable skills for AI coding assistants. Works with Claude Code, Codex, OpenCod
 |-------|-------------|
 | `git-repo-setup` | Checklist for new repos - always set local git identity |
 | `terminal-recording` | Create terminal recordings with asciinema |
+| `senior-engineer-note-maker` | High-readability engineering markdown with aligned tables, ASCII diagrams, citations, and provenance scaffolds |
 
 ## Installation
 
@@ -32,6 +33,7 @@ git clone git@github.com:Liam-Deacon/agent-skills.git ~/.codex/skills/personal
 # Or install individual skills
 cp -r git-repo-setup ~/.codex/skills/
 cp -r src/terminal-recording ~/.codex/skills/
+cp -r senior-engineer-note-maker ~/.codex/skills/
 ```
 
 ### OpenCode

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Reusable skills for AI coding assistants. Works with Claude Code, Codex, OpenCod
 | `git-repo-setup` | Checklist for new repos - always set local git identity |
 | `terminal-recording` | Create terminal recordings with asciinema |
 | `senior-engineer-note-maker` | High-readability engineering markdown with aligned tables, ASCII diagrams, citations, and provenance scaffolds |
+| `mock-review-html` | Tabbed GitHub-style HTML mockup of held PR review drafts, with real PR context (description, timeline, verbatim diff strips) for pre-posting human review |
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Reusable skills for AI coding assistants. Works with Claude Code, Codex, OpenCod
 | `terminal-recording` | Create terminal recordings with asciinema |
 | `senior-engineer-note-maker` | High-readability engineering markdown with aligned tables, ASCII diagrams, citations, and provenance scaffolds |
 | `mock-review-html` | Tabbed GitHub-style HTML mockup of held PR review drafts, with real PR context (description, timeline, verbatim diff strips) for pre-posting human review |
+| `markdown-doc-enrichment` | Engineering-doc upgrade pass: mermaid over ASCII, admonitions, posterity folds, decision-history versioning, and a red-team fact-check before shipping |
+| `html-review-pack` | Self-contained offline HTML artifacts (chat mockups, tabbed packs, decision packs) so humans review outward-bound content in its destination medium before it fires |
 
 ## Installation
 

--- a/html-review-pack/SKILL.md
+++ b/html-review-pack/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: html-review-pack
+description: Build a single self-contained offline HTML artifact that mimics the destination medium (chat thread, PR review, decision pack, report) so a human can review outward-bound content in context before anything is sent or posted. Use when drafting messages, reviews, or decisions that need sign-off, when asked for a "mockup" or "pack", or whenever held content should be eyeballed as it will actually land.
+---
+
+# html-review-pack
+
+Outward-bound content (messages, reviews, decision summaries) reads differently in
+its destination medium than in a markdown draft. A review pack closes that gap: one
+self-contained HTML file that renders the held content the way it will actually
+land, so the human approves or edits with full context, before anything fires.
+
+Related: `mock-review-html` in this repo is the specialised instance for pull
+request reviews (GitHub-look tabs, diff strips, pending pills). This skill is the
+general craft.
+
+## Variants (pick by destination)
+
+- **Chat-thread mockup** — message boxes styled like the chat product, in send
+  order, each followed by a raw-text block for copy-paste, plus a landing note
+  describing where each message goes (channel, thread, attachment).
+- **Tabbed pack** — one tab per item (per PR, per decision, per document); a tab
+  strip, a status header, item content below. Right for "go over these one by one".
+- **Decision pack** — tabs for: the decision in one page, the diagram, the
+  comparison matrix (inline table, not an image, so it is crisp), options
+  considered with verdicts, change summary, next steps. Built to be attached and
+  read offline by someone who was not in the room.
+- **Report page** — single-column analysis with a summary up top and folded detail.
+
+## Principles (non-negotiable)
+
+1. **Fidelity over beauty.** The pack shows the exact words that will ship. Never
+   paraphrase, trim, or improve the held text in the rendering step. If a section
+   fails to parse, render it raw in a `<pre>` rather than dropping it.
+2. **Self-contained.** One `.html` file: inline CSS, vanilla JS, no CDN, no
+   external fonts or images. It must open from `file://` and survive being
+   emailed or attached.
+3. **Held means visibly held.** A bold status pill (`PENDING — NOTHING SENT`)
+   in a sticky header. Nobody should mistake a mockup for a record of something
+   sent.
+4. **Edits go to the source, not the artifact.** The pack is generated; the held
+   drafts are the truth. The human's wording tweaks are applied to the draft
+   files and the pack regenerates.
+
+## Build loop
+
+- **Never hand-write the HTML.** Write a small build script (Python, stdlib) that
+  parses the draft sources and emits the page: `parse(source) → model`,
+  `render(model) → html`, one `emit()`. Deterministic: same inputs, same output —
+  that is what makes iteration cheap (edit one draft, re-run, reload).
+- **Mini-markdown renderer**: escape raw HTML first, then code spans, bold, links,
+  lists, headings, pipe tables; re-enable a small whitelist of tags the
+  destination itself allows (`details`, `summary`, `br`). Real-world content uses
+  more markdown than your drafts do — render headings and tables or they arrive
+  as visible noise.
+- **Verify before handing back**: per-item counts in the source equal rendered
+  counts; required markers present (`grep -c PENDING`); no external resources;
+  spot-check a few content strings verbatim.
+- **Render-check**: serve the file (`python3 -m http.server`), screenshot with a
+  headless browser, look at the screenshot. A page that "should" render is not a
+  checked page. Report the screenshot path.
+- **Report ambiguities** the spec did not cover; fold the answers back into the
+  spec so the next generation needs no judgement calls.
+
+## Delivery
+
+- Open the file locally for the reviewer; name the path.
+- The human reviews in the artifact, gives wording edits in chat (or directly in
+  the sources); apply to sources, regenerate, reopen.
+- Only after explicit approval does anything fire — and firing is a separate,
+  validated step (anchors checked, dry-run printed, then live), never a side
+  effect of generating the pack.
+
+## Antipatterns
+
+- ❌ Hand-authored HTML that drifts from the drafts it claims to show.
+- ❌ "Improving" the held text during rendering.
+- ❌ External CSS/JS/fonts that break offline or leak the content to a CDN.
+- ❌ No pending marker, so a screenshot of the mockup reads as a sent record.
+- ❌ Editing the artifact instead of the sources.
+- ❌ Declaring it renders without looking at a screenshot.

--- a/markdown-doc-enrichment/SKILL.md
+++ b/markdown-doc-enrichment/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: markdown-doc-enrichment
+description: Upgrade engineering markdown (ADRs, design docs, platform overviews, decision records) so it renders well on GitHub and survives scrutiny — mermaid over ASCII, admonitions for load-bearing callouts, details-folds for posterity content, decision-history versioning, and a red-team fact-check pass before shipping. Use when writing or amending ADRs, architecture docs, comparison matrices, or any doc that records a decision someone may later contest.
+---
+
+# markdown-doc-enrichment
+
+Engineering docs fail two ways: they render as walls of monospace nobody reads, or
+they assert things nobody verified. This skill fixes both. It applies to ADRs,
+design docs, platform overviews, migration guides, and decision records — anything
+where a future reader needs to trust both the rendering and the claims.
+
+## Diagrams
+
+- **Mermaid over ASCII** wherever GitHub renders it well: flowcharts, sequence
+  diagrams, simple architecture. ASCII art breaks at the first edit and reads as
+  neglect; mermaid diffs cleanly and renders natively.
+- **Complex diagrams that mermaid handles badly** (dense matrices, styled trees for
+  non-technical audiences): build an HTML artifact, render it to PNG/SVG with a
+  headless browser, and **commit the image** under an assets convention next to the
+  docs (`docs/<area>/assets/<topic>/<name>.png`), embedded with a relative path.
+  Keep the HTML source somewhere regenerable; the image and the doc must change in
+  the same commit when content changes (a matrix image rendered before a verdict
+  row was added is a lie).
+- Private repos: committed images render in Files view and rendered docs;
+  comment-attachment URLs do not survive in private repos, so never rely on them
+  for doc content.
+
+## Admonitions (load-bearing callouts)
+
+Use GitHub admonitions for the sentences that carry the decision:
+
+- `> [!IMPORTANT]` — the agreed decision, its revisit clause, anything a reader
+  must not skim past.
+- `> [!WARNING]` — ruled-out options and the reason, so nobody re-proposes them
+  innocently.
+- `> [!NOTE]` — standing rules, grandfathering, conventions that survive the doc.
+
+One admonition per point. A page of admonitions is a page of body text.
+
+## Posterity folds
+
+Decisions age better when the reasoning stays present but folded:
+
+- Keep **verdicts visible**: a comparison matrix keeps every option as a column and
+  gains an **Outcome row** (adopted / parked with revisit condition / ruled out with
+  reason). Deleting losing options invites relitigating them.
+- Fold the long-form rationale in `<details><summary>` blocks: prior-version
+  reasoning, measured-evidence appendices, alternatives considered. The bar: a
+  reader can see things WERE considered and that the decision rests on named
+  constraints, without wading through them.
+- Never fold the decision itself, the revisit clause, or the decision history.
+
+## Versioning and decision history
+
+When a decision doc changes materially:
+
+- Frontmatter gains `version` (bump major on a changed decision, minor on scope or
+  clarity changes) and `updated_at`.
+- Add a `## Decision history` section: one line per version — date, what changed,
+  why. This is how a reader learns the v1 proposal was rescoped without spelunking
+  git.
+- **Statuses stay honest.** A decision agreed verbally is `proposed` until the
+  ratification mechanism (usually peer review of the amending PR) completes. Do not
+  mark `accepted` because a meeting went well; record "agreed in the <date> session;
+  ratification is approval of this PR".
+
+## The red-team pass (before shipping, always)
+
+Silently verify, in place, before the doc goes out:
+
+1. **Every number** (caps, limits, line counts, durations) against its source.
+2. **Every reference**: PR/issue numbers resolve to what the prose claims;
+   cross-repo references are fully qualified (`owner/repo#123` — a bare `#123`
+   points into whatever repo hosts the doc).
+3. **Every quote and attribution**: people only said what the transcript says;
+   prefer "the session left X open" over "we agreed X" unless the words exist.
+4. **Every date**: relative dates become absolute; day-of-week claims are checked
+   against a calendar (wrong-day errors are common and corrosive).
+5. **Every named artifact still exists**: files, flags, classes, packages get a
+   grep before the doc asserts them.
+6. Claims that fail verification get fixed or hedged — never shipped on vibes.
+
+Do not advertise the pass in the doc; the output is correctness, not a section
+about correctness.
+
+## Voice
+
+Plain prose. No em dashes, no theatrical colons or semicolons, no bullet-summary
+endings that restate the document. Short sentences, commas where needed. Every
+criticism of an alternative is paired with the constraint that killed it.
+
+## Antipatterns
+
+- ❌ ASCII "figures" in docs that GitHub would render as mermaid.
+- ❌ Deleting ruled-out options instead of recording their verdicts.
+- ❌ `status: accepted` on the strength of a conversation.
+- ❌ Bare `#123` cross-repo references.
+- ❌ A matrix image that lags the matrix it pictures.
+- ❌ Shipping a number, date, or quote nobody checked.

--- a/mock-review-html/SKILL.md
+++ b/mock-review-html/SKILL.md
@@ -1,0 +1,212 @@
+---
+name: mock-review-html
+description: Render held/draft PR review text as a single self-contained HTML page that loosely mimics the GitHub review UI, tabbed with one tab per PR, so a human can eyeball exactly how reviews will land before they are posted. Use when asked to mock, preview, or visualise PR review comments, a "review pack", or held review drafts.
+---
+
+# mock-review-html
+
+Turn one or more PR review drafts (markdown) into ONE self-contained HTML page that looks
+loosely like GitHub's PR review UI: a tab per PR, each tab showing the top-level review
+box plus the in-line comments as file-anchored cards. The page is for HUMAN REVIEW of
+held drafts before posting — always show a "pending / not posted" marker.
+
+## Input convention
+
+Each draft is a markdown file shaped like:
+
+```markdown
+# HELD DRAFT — review for <repo> #<number> (<short title>)
+
+> Fire as: <verdict guidance, e.g. "one GitHub review (Comment)">
+
+## Top-level review body
+
+<paragraphs, may contain `code`, **bold**, [links](url), numbered lists>
+
+## In-line comments
+
+### `path/to/file.py` (anchor description)
+> <comment body as one or more blockquote lines>
+
+### `another/file` (second comment, ...)
+> <body>
+```
+
+Parse leniently: the H1 carries repo + PR number + title; every `###` under
+"In-line comments" is one anchored comment whose heading is the file path (strip
+backticks) plus an optional parenthetical anchor note; the blockquote lines beneath it
+are the comment body. The same file path may appear in multiple `###` headings
+(several comments on one file); render each as its own card, distinguished by the
+anchor note. Anything in the "Fire as" line containing "request changes"
+(case-insensitive) renders the red REQUEST CHANGES pill; otherwise the grey COMMENT pill.
+
+## PR context (use it when present)
+
+If a `context/` directory sits next to the drafts, consume per-PR ground truth:
+
+- `<number>.json` — from `gh pr view <n> --repo <owner>/<repo> --json
+  number,url,title,body,baseRefName,headRefName,isDraft,author,createdAt,additions,deletions,changedFiles,comments,reviews,commits`
+- `<number>.diff` — `gh pr diff <n>` (unified diff)
+- `<number>.review-comments.json` — `gh api repos/<owner>/<repo>/pulls/<n>/comments`
+  (existing in-line review comments, each with `path`, `html_url`, `diff_hunk`)
+
+When the caller has not pre-fetched these, fetch them with those exact commands first.
+The JSON overrides anything guessed from the draft (title, branches, draft state).
+
+Render per tab, in this order:
+
+1. **PR header**: the title links to `url` (open in new tab). Meta line beneath:
+   `opened by <author> on <date> · +<additions> −<deletions> · <changedFiles> files`,
+   plus the `head → base` branch chips from the JSON.
+2. **Description**: the PR body as the first timeline card (author avatar, "opened
+   this pull request", date). Render with the mini-markdown rules. If the body exceeds
+   ~40 lines, show the first paragraph and fold the rest in `<details>`.
+3. **Timeline**: existing issue comments and reviews merged chronologically, each a
+   card with author, date, body, and a small "view on GitHub ↗" link to its `url`.
+   Bot entries (vercel, linear-code, datadog, CI/quality bots, `[bot]` suffix)
+   collapse to one-line rows (icon, author, date, link) since their bodies are noise;
+   human and Copilot review bodies render in full. Existing in-line review comments
+   from `review-comments.json` group under their parent review (or a "Review comments"
+   row) as a collapsed `<details>` list of `path` links to each `html_url`.
+4. **The pending review box** (the held draft) renders AFTER the timeline, where
+   GitHub puts a not-yet-submitted review. Make it unmistakably the draft: amber left
+   border, the PENDING pill in the header row.
+5. **Diff context on pending in-line comments**: for each anchored card, find the
+   file's hunks in `<number>.diff` and render 3–8 lines as a GitHub-style diff table
+   above the comment: line-number gutter, `+` rows on `#e6ffec`, `-` rows on
+   `#ffebe9`, context rows white, monospace, the standard blue hunk header
+   (`@@ … @@`) on `#ddf4ff`. Choose the hunk whose content matches what the comment
+   quotes (identifier, string literal, env var); if nothing matches, the file's first
+   hunk; if the file does not appear in the diff at all (repo-level or doc-wide
+   comments), show a muted "no diff context for this anchor" bar instead.
+   NEVER fabricate or trim-and-reflow code lines — copy them from the diff verbatim
+   (content-verbatim: HTML-escaping the characters for rendering is required, reflowing
+   or paraphrasing is not allowed). A "no diff context" bar on a real file path is also
+   a useful signal to surface in the report: it usually means the PR does not modify
+   that file, so the comment cannot be posted as an in-line anchor and must move to the
+   review body when fired.
+
+## Output structure (single .html, inline CSS, vanilla JS, no CDN)
+
+1. **Page chrome**: light GitHub palette — page background `#f6f8fa`, cards `#ffffff`,
+   borders `#d0d7de`, text `#1f2328`, muted `#59636e`, link `#0969da`. Font stack:
+   `-apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif`;
+   code/diff in `ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace`.
+2. **Sticky header**: page title, a bold amber `PENDING — NOTHING POSTED` pill, and the
+   tab strip. One tab per PR labelled `#<number>` with a short slug; active tab gets the
+   classic GitHub orange underline (`border-bottom: 2px solid #fd8c73`) and bold text.
+3. **Per tab** (when `context/` exists, the order is header → description → timeline →
+   pending review box → in-line cards, per the PR-context section):
+   - PR title line: repo + `#number`, the PR title (linked to the PR when the URL is
+     known), a grey `Draft` chip (omit the chip entirely when the PR is not a draft —
+     never render a "Not Draft" chip) and `head → base` branch chips if known.
+   - **Review box** (mimic GitHub's review summary): rounded card, header row with a
+     32px avatar circle (reviewer initials), `<b>reviewer</b> reviewed` + relative time
+     "pending", and the COMMENT / REQUEST CHANGES pill. Body = the top-level review body
+     rendered with the mini-markdown rules below.
+   - **In-line comments**: each as a GitHub-style anchored card —
+     a file header bar (monospace path on `#f6f8fa`, rounded top, with the anchor note
+     right-aligned in muted text), THEN a diff context strip sourced from
+     `context/<n>.diff` per the PR-context section (or from the draft if it embeds one;
+     never invented), then the comment card: small avatar, reviewer name, body. Stack
+     the cards in draft order.
+4. **Mini-markdown rendering** (regex-level is fine):
+   `` `x` `` → `<code>`, `**x**` → `<b>`, `[t](u)` → `<a href>`, blank-line split →
+   `<p>`, lines starting `1.`/`-` grouped into `<ol>/<ul>`. Escape raw HTML first.
+   Keep paragraphs intact — do NOT reflow or reword the draft text. The page must show
+   the exact words that will be posted.
+
+   Real PR bodies and bot/Copilot reviews use more of GitHub-flavoured markdown than
+   the drafts do, so the renderer must also handle:
+   - `#`–`####` headings → step-sized bold headings (GitHub-ish: h3 ≈ 1.05em bold with
+     a little top margin). Never leave literal `#` runs visible.
+   - Pipe tables: a run of `|`-delimited lines whose second line is the `|---|`
+     separator → a real `<table>` (collapsed borders, `#d0d7de` lines, header row on
+     `#f6f8fa`). One table row per source line — never let table rows merge into a
+     paragraph.
+   - A small whitelist of HTML tags GitHub itself allows in comments, re-enabled
+     AFTER escaping: `<details>`, `<summary>`, `<br>`. A `<details>` block in a body
+     becomes a real collapsible fold (that is how it behaves on GitHub). Everything
+     else stays escaped text.
+5. **Tabs JS**: one click handler toggling `.on` classes; no frameworks.
+6. **Footer**: file list of the source drafts + generation note.
+
+## Design spec (explicit tokens)
+
+Replicate these values exactly; the goal is "obviously GitHub" at a glance, not
+pixel-perfect cloning.
+
+| Token | Value |
+|-------|-------|
+| Page background | `#f6f8fa` |
+| Card background | `#ffffff` |
+| Borders | `1px solid #d0d7de`, radius `6px` |
+| Text / muted / link | `#1f2328` / `#59636e` / `#0969da` |
+| Active tab | `border-bottom: 2px solid #fd8c73`, bold text |
+| PENDING pill | bold; text `#9a6700`, bg `#fff8c5`, border `#d4a72c66`, radius `999px` |
+| COMMENT pill | bg `#eff1f3`, text `#59636e` |
+| REQUEST CHANGES pill | bg `#ffebe9`, text `#cf222e` |
+| Draft chip | grey outline chip beside the title; omitted entirely for non-drafts |
+| Branch chips | monospace, bg `#ddf4ff`, text `#0969da` |
+| Avatars | CSS initial-circles; 32px in review boxes, 24px in timeline and comment cards; background colour from a small hash of the author name |
+| Diff rows add / del / context | bg `#e6ffec` / `#ffebe9` / `#ffffff` |
+| Diff hunk header (`@@ … @@`) | bg `#ddf4ff`, text `#59636e` |
+| Line-number gutters | muted text on `#f6f8fa`; add gutter tinted `#ccffd8`, del gutter `#ffd7d5` |
+| Pending review box accent | `border-left: 4px solid #d4a72c` |
+| File header bar on comment cards | monospace path on `#f6f8fa`, rounded top corners |
+| Fonts | system stack for prose; `ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace` for paths, code and diffs |
+| Content column | max-width ~980px, centred; the sticky header spans full width |
+
+Anatomy of one tab, top to bottom: PR header card (linked title, meta line, branch
+chips) → DESCRIPTION label + opener card → TIMELINE label + chronological cards and
+collapsed bot rows → YOUR PENDING REVIEW label + the amber-accented review box →
+the pending in-line comment cards (file bar, diff strip, comment) → footer.
+Section labels are small grey uppercase, GitHub-settings style.
+
+## Rules
+
+- **Fidelity over beauty**: never paraphrase, truncate, or "improve" the review text.
+  If a draft section fails to parse, render it raw in a `<pre>` inside the tab rather
+  than dropping it.
+- Self-contained: no external fonts, images, or scripts. Avatars are CSS initial-circles.
+- Order tabs as given by the caller (a firing order), else by PR number.
+- Render-check if a browser loop is available (`playwright-cli` + `python3 -m http.server`),
+  else state that the check was skipped.
+- Output path: as instructed by the caller; default `review-pack-mockup.html` next to
+  the drafts.
+
+## Replication recipe
+
+How a fresh agent reproduces the artifact, end to end:
+
+1. Collect the draft files matching the input convention and note the caller's tab
+   order (a firing order beats PR-number order when given).
+2. Fetch the per-PR context into `context/` with the three `gh` commands in the
+   PR-context section. If `gh` or the repo is unavailable, proceed from drafts alone;
+   the page degrades gracefully (no links, no timeline, no diff strips).
+3. Do not hand-write the HTML. Write a build script (Python, stdlib only) with this
+   shape, then run it:
+   - `parse_draft(path)` → repo, number, title, fire-as verdict, body, and the list
+     of (file path, anchor note, body) comments
+   - `load_context(n)` → merged dict from the three context files, or `None`
+   - `mini_md(text)` → HTML per the mini-markdown rules (escape first; whitelist
+     `details`/`summary`/`br` back in; headings, lists, pipe tables)
+   - `pick_hunk(diff, path, comment)` → the 3–8 line strip as (kind, old_no, new_no,
+     text) rows, chosen by matching identifiers the comment quotes; `None` when the
+     file is not in the diff
+   - `render_tab(draft, ctx)` per tab, and one `emit()` writing the single file
+4. The script must be deterministic: same inputs, same output. That is what makes
+   iteration cheap (edit one draft, re-run, reload) and lets a reviewer trust that
+   the page matches the drafts.
+5. Run the verify checklist below, then the render-check, and hand back: per-check
+   results, screenshot paths, and any spec ambiguity you hit, so the spec improves.
+
+## Verify before handing back
+
+- Every draft file produced exactly one tab; per tab, count of `###` comments in the
+  source equals the number of anchored cards rendered.
+- With `context/`: every tab's title links to the PR `url`; the timeline renders one
+  entry per issue comment + review in the JSON (collapsed counts as rendered); every
+  diff strip's code lines appear verbatim in `context/<n>.diff` (spot-check a few by
+  grep); mini-markdown in real comment bodies did not leak raw HTML.
+- `grep -c 'PENDING'` ≥ 1; no `http://` CDN/script tags; file opens from `file://`.

--- a/senior-engineer-note-maker/SKILL.md
+++ b/senior-engineer-note-maker/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: senior-engineer-note-maker
+description: Create highly human-readable engineering markdown for documentation, PR descriptions, issue descriptions, and PR comments. Use when outputs require aligned markdown tables, ASCII diagrams, evidence-based citations, GitHub permalinks with metadata comments, and heredoc-safe GitHub CLI authoring.
+---
+
+# Senior Engineer Note Maker
+
+Produce markdown that is readable in raw form and rendered form, with explicit evidence and traceability.
+
+## Output Rules
+
+1. Use whitespace-aligned markdown tables whenever comparing options, risks, metrics, or outcomes.
+2. Use ASCII diagrams for architecture, data flow, lifecycle, and process flow explanations.
+3. Use numeric citations `[1]`, `[2]` for factual claims, decisions, and implementation rationale.
+4. Prefer inline descriptive links for repo/issue/code references.
+5. Use GitHub permalinks with line ranges for code references.
+6. Add hidden permalink metadata comments near permalinks:
+
+```html
+<!-- permalink-meta: branch=<branch>, timestamp=<ISO8601> -->
+```
+
+## Provenance Frontmatter
+
+When generating documentation-style markdown, prepend YAML frontmatter based on the profile in `references/internal-frontmatter-schema.md`.
+
+Author identity priority is fixed:
+1. Email
+2. Full name
+3. Git handle
+
+Use `scripts/render_note_scaffold.sh` to generate compliant scaffolds.
+
+## PR and Comment Authoring
+
+Avoid literal `\\n` in GitHub PR descriptions and comments.
+Use heredoc workflows from `scripts/gh_heredoc_templates.sh`.
+
+## Workflow
+
+1. Select artifact type (`doc`, `pr`, `issue`, `comment`).
+2. Generate scaffold:
+
+```bash
+scripts/render_note_scaffold.sh --type doc --title "Design Note: Example"
+```
+
+3. Fill decision details, aligned tables, and ASCII diagrams.
+4. Add citations and cross-references.
+5. If referencing code, add permalink metadata comments.
+6. For GitHub posting, use heredoc templates:
+
+```bash
+scripts/gh_heredoc_templates.sh
+```
+
+## References
+
+- Style and readability patterns: `references/style-guide.md`
+- Citation and cross-reference patterns: `references/citation-patterns.md`
+- Permalink and metadata patterns: `references/github-permalink-patterns.md`
+- Provenance frontmatter profile: `references/internal-frontmatter-schema.md`
+- End-to-end examples: `references/examples.md`
+
+## Validation
+
+Run output checks after scaffold generation:
+
+```bash
+scripts/validate_scaffold_output.sh
+```

--- a/senior-engineer-note-maker/agents/openai.yaml
+++ b/senior-engineer-note-maker/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Senior Engineer Note Maker"
+  short_description: "Readable engineering markdown with citations"
+  default_prompt: "Write a senior-level markdown doc, PR description, issue description, or PR comment using aligned tables, ASCII diagrams, and evidence-based citations."

--- a/senior-engineer-note-maker/references/citation-patterns.md
+++ b/senior-engineer-note-maker/references/citation-patterns.md
@@ -1,0 +1,33 @@
+# Citation and Cross-Reference Patterns
+
+## Numeric References
+
+Use numeric references for claims and decisions:
+
+```markdown
+We selected batched writes to reduce lock churn [1].
+```
+
+At the end:
+
+```markdown
+## References
+
+[1]: https://example.com/design-doc
+```
+
+## Inline Links
+
+Use inline links for repo objects:
+
+```markdown
+See [myrepo issues](https://github.com/myorg/myrepo/issues).
+```
+
+## Cross-References
+
+Link related sections and docs directly:
+
+```markdown
+See [Risk Matrix](#risk-matrix) and [ADR-001](./ADR-001.md).
+```

--- a/senior-engineer-note-maker/references/examples.md
+++ b/senior-engineer-note-maker/references/examples.md
@@ -1,0 +1,31 @@
+# Examples
+
+## Issue Description Skeleton
+
+~~~markdown
+## Problem
+
+Retries do not apply jitter and spike backend error rates [1].
+
+## Proposed Change
+
+| Area        | Change               | Benefit                |
+| ----------- | -------------------- | ---------------------- |
+| HTTP client | Add jittered backoff | Reduce coordinated load|
+| Worker      | Retry cap at 5       | Bound execution time   |
+
+## Flow
+
+```text
+Request -> Client -> Retry Logic -> Upstream Service
+```
+
+## Evidence
+
+- See [`client.py#L42-L98`](https://github.com/myorg/myrepo/blob/abc/path/client.py#L42-L98)
+<!-- permalink-meta: branch=feature/retry, timestamp=2026-02-12T15:20:00Z -->
+
+## References
+
+[1]: https://aws.amazon.com/builders-library/timeouts-retries-and-backoff-with-jitter/
+~~~

--- a/senior-engineer-note-maker/references/github-permalink-patterns.md
+++ b/senior-engineer-note-maker/references/github-permalink-patterns.md
@@ -1,0 +1,20 @@
+# GitHub Permalink Patterns
+
+## Code Links
+
+Use permalinks with line ranges when highlighting behavior.
+
+```markdown
+The retry loop ignores 429 backoff in
+[`worker.py#L84-L113`](https://github.com/myorg/myrepo/blob/abc123/path/worker.py#L84-L113).
+<!-- permalink-meta: branch=feature/retry-fix, timestamp=2026-02-12T15:20:00Z -->
+```
+
+## Metadata Comment Rule
+
+Always place metadata comment immediately after the permalink paragraph.
+
+Required keys:
+
+- `branch`
+- `timestamp` (ISO8601 UTC preferred)

--- a/senior-engineer-note-maker/references/internal-frontmatter-schema.md
+++ b/senior-engineer-note-maker/references/internal-frontmatter-schema.md
@@ -1,0 +1,54 @@
+# Frontmatter Profile (Relaxed Compatibility)
+
+This skill uses a stage-doc style frontmatter profile and intentionally relaxes strict author regex validation to preserve provenance richness.
+
+## Required Fields
+
+Every documentation scaffold should include:
+
+| Field | Required | Notes |
+| ----- | -------- | ----- |
+| `id` | yes | `{repo}/{slug}` style identifier |
+| `title` | yes | Human-readable title |
+| `summary` | yes | 1-3 sentence summary |
+| `repo` | yes | Source repository |
+| `path` | yes | `docs/.../*.md` style path |
+| `type` | yes | `documentation`, `adr`, `runbook`, `guide`, `reference`, `rfc`, `prd`, `deprecation` |
+| `category` | yes | Team category taxonomy |
+| `intended_audience` | yes | One or more audience tags |
+| `status` | yes | `active`, `draft`, `deprecated`, `archived` |
+| `visibility` | yes | `internal`, `public`, `restricted` |
+| `created_at` | yes | ISO date |
+| `updated_at` | yes | ISO date |
+| `authors` | yes | Ordered by identity priority (below) |
+| `sync` | yes | Boolean sync indicator |
+
+## Author Identity Resolution
+
+Resolve each author using this strict priority:
+
+1. Email
+2. Full name
+3. Git handle
+
+Example:
+
+```yaml
+authors:
+  - "engineer@example.com"
+  - "Engineer Name"
+  - "@engineerhandle"
+```
+
+If only one format is available, use it directly.
+
+## Optional Provenance Fields
+
+Include when known:
+
+- `source_files`
+- `related_docs`
+- `tags`
+- `owner_team`
+- `version`
+- `review_frequency`

--- a/senior-engineer-note-maker/references/style-guide.md
+++ b/senior-engineer-note-maker/references/style-guide.md
@@ -1,0 +1,38 @@
+# Style Guide
+
+## Primary Goal
+
+Maximize reader comprehension without requiring markdown rendering.
+
+## Table Rules
+
+- Align pipes and cell spacing so tables remain legible in raw markdown.
+- Use short headers.
+- Keep one fact per cell.
+
+Example:
+
+```markdown
+| Option | Complexity | Risk | Notes |
+| ------ | ---------- | ---- | ----- |
+| A      | Low        | Low  | Fast rollout |
+| B      | Medium     | High | Migration required |
+```
+
+## Diagram Rules
+
+Use ASCII diagrams for high-level flow before detailed sections.
+
+```text
+Client --> API --> Service --> DB
+```
+
+## Section Order
+
+1. Context
+2. Decision / Proposal
+3. Comparison summary (table)
+4. Architecture/flow (ASCII)
+5. Risks and mitigations
+6. Evidence and citations
+7. Next actions

--- a/senior-engineer-note-maker/scripts/gh_heredoc_templates.sh
+++ b/senior-engineer-note-maker/scripts/gh_heredoc_templates.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cat <<'TEMPLATE'
+# PR description update (avoids literal \n)
+cat > /tmp/pr-body.md <<'PR_BODY'
+## Summary
+
+TODO
+
+## Changes
+
+| Area | Change | Why |
+| ---- | ------ | --- |
+| TODO | TODO   | TODO |
+PR_BODY
+
+gh pr edit <PR_NUMBER> --body-file /tmp/pr-body.md
+
+# PR comment (avoids literal \n)
+cat > /tmp/pr-comment.md <<'PR_COMMENT'
+Please review the retry flow in
+[`client.py#L42-L98`](https://github.com/myorg/myrepo/blob/<sha>/path/client.py#L42-L98).
+<!-- permalink-meta: branch=<branch>, timestamp=<ISO8601> -->
+PR_COMMENT
+
+gh pr comment <PR_NUMBER> --body-file /tmp/pr-comment.md
+TEMPLATE

--- a/senior-engineer-note-maker/scripts/render_note_scaffold.sh
+++ b/senior-engineer-note-maker/scripts/render_note_scaffold.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TYPE=""
+TITLE=""
+REPO="your-repo"
+DOC_PATH="docs/TODO.md"
+DOC_TYPE="documentation"
+CATEGORY="engineering"
+AUDIENCE="llm-agent"
+STATUS="draft"
+VISIBILITY="internal"
+SYNC="false"
+DATE="$(date +%F)"
+EMAILS=""
+NAMES=""
+HANDLES=""
+
+usage() {
+  cat <<'USAGE'
+Usage: render_note_scaffold.sh --type <doc|pr|issue|comment> --title <title> [options]
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --type) TYPE="$2"; shift 2 ;;
+    --title) TITLE="$2"; shift 2 ;;
+    --repo) REPO="$2"; shift 2 ;;
+    --path) DOC_PATH="$2"; shift 2 ;;
+    --doc-type) DOC_TYPE="$2"; shift 2 ;;
+    --category) CATEGORY="$2"; shift 2 ;;
+    --audience) AUDIENCE="$2"; shift 2 ;;
+    --status) STATUS="$2"; shift 2 ;;
+    --visibility) VISIBILITY="$2"; shift 2 ;;
+    --sync) SYNC="$2"; shift 2 ;;
+    --date) DATE="$2"; shift 2 ;;
+    --author-email) EMAILS="$2"; shift 2 ;;
+    --author-name) NAMES="$2"; shift 2 ;;
+    --author-handle) HANDLES="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown arg: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+if [[ -z "$TYPE" || -z "$TITLE" ]]; then
+  usage
+  exit 1
+fi
+
+slugify() { echo "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//'; }
+trim() { echo "$1" | sed -E 's/^\s+//; s/\s+$//'; }
+
+emit_authors() {
+  local source=""
+  if [[ -n "$EMAILS" ]]; then
+    source="$EMAILS"
+  elif [[ -n "$NAMES" ]]; then
+    source="$NAMES"
+  elif [[ -n "$HANDLES" ]]; then
+    source="$HANDLES"
+  else
+    source="@unknown-author"
+  fi
+
+  IFS=',' read -r -a arr <<< "$source"
+  for raw in "${arr[@]}"; do
+    v="$(trim "$raw")"
+    [[ -n "$v" ]] && printf '  - "%s"\n' "$v"
+  done
+}
+
+if [[ "$TYPE" == "doc" ]]; then
+  slug="$(slugify "$TITLE")"
+  cat <<DOC
+---
+id: ${REPO}/${slug}
+title: "${TITLE}"
+summary: "TODO: Add concise summary (10-500 chars)."
+repo: ${REPO}
+path: ${DOC_PATH}
+type: ${DOC_TYPE}
+category: ${CATEGORY}
+intended_audience:
+DOC
+  IFS=',' read -r -a aud <<< "$AUDIENCE"
+  for a in "${aud[@]}"; do
+    aa="$(trim "$a")"
+    [[ -n "$aa" ]] && printf '  - %s\n' "$aa"
+  done
+  cat <<DOC2
+status: ${STATUS}
+visibility: ${VISIBILITY}
+created_at: ${DATE}
+updated_at: ${DATE}
+authors:
+DOC2
+  emit_authors
+  cat <<DOC3
+sync: ${SYNC}
+---
+
+# ${TITLE}
+
+## Context
+
+TODO
+
+## Decision
+
+TODO
+
+## Comparison Summary
+
+| Option | Complexity | Risk | Rationale |
+| ------ | ---------- | ---- | --------- |
+| A      | TODO       | TODO | TODO      |
+| B      | TODO       | TODO | TODO      |
+
+## Flow
+
+~~~text
+Input --> Process --> Output
+~~~
+
+## Evidence
+
+- TODO: Add code/repo links
+
+## References
+
+[1]: https://example.com
+DOC3
+  exit 0
+fi
+
+cat <<OTHER
+## Summary
+
+TODO
+
+## Details
+
+| Area | Change | Impact |
+| ---- | ------ | ------ |
+| TODO | TODO   | TODO   |
+
+## Flow
+
+~~~text
+Caller --> Component --> Result
+~~~
+
+## Evidence
+
+- TODO: Add permalink with line range
+<!-- permalink-meta: branch=<branch>, timestamp=$(date -u +%FT%TZ) -->
+
+## References
+
+[1]: https://example.com
+OTHER

--- a/senior-engineer-note-maker/scripts/validate_scaffold_output.sh
+++ b/senior-engineer-note-maker/scripts/validate_scaffold_output.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RENDER="$DIR/render_note_scaffold.sh"
+
+check_contains() {
+  local haystack="$1"
+  local needle="$2"
+  local msg="$3"
+  if ! grep -Fq "$needle" <<<"$haystack"; then
+    echo "FAIL: $msg" >&2
+    exit 1
+  fi
+}
+
+out_email="$($RENDER --type doc --title "Test Doc" --author-email "person@example.com" --author-name "Person Name" --author-handle "@person")"
+check_contains "$out_email" '  - "person@example.com"' "email priority failed"
+
+out_name="$($RENDER --type doc --title "Test Doc" --author-name "Person Name" --author-handle "@person")"
+check_contains "$out_name" '  - "Person Name"' "name priority failed"
+
+out_handle="$($RENDER --type doc --title "Test Doc" --author-handle "@person")"
+check_contains "$out_handle" '  - "@person"' "handle fallback failed"
+
+check_contains "$out_email" 'id: your-repo/test-doc' "id generation failed"
+check_contains "$out_email" 'sync: false' "sync default missing"
+
+echo "PASS: scaffold output validation succeeded"


### PR DESCRIPTION
## Summary

Adds a sanitized `senior-engineer-note-maker` skill for producing highly readable engineering markdown across docs, PR descriptions, issue descriptions, and PR comments.

## Included

- New skill: `senior-engineer-note-maker/`
- Aligned markdown table and ASCII diagram guidance
- Citation and cross-reference guidance
- GitHub permalink metadata comment guidance
- Heredoc-safe GitHub CLI templates (avoid literal `\\n`)
- Provenance frontmatter profile with relaxed author identity compatibility
- Author identity resolution priority in scaffold generator:
  1. Email
  2. Full name
  3. Git handle
- Script-level validation for scaffold output and author-priority behavior

## Validation

- `python3 /Users/liam/.codex/skills/.system/skill-creator/scripts/quick_validate.py /Users/liam/repos/agent-skills/senior-engineer-note-maker`
- `/Users/liam/repos/agent-skills/senior-engineer-note-maker/scripts/validate_scaffold_output.sh`

## Sanitization

- Removed Antarctica-specific identifiers and examples.
- Kept methodology and formatting standards identical.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Senior Engineer Note Maker" skill: creates scaffolded, citation-backed engineering notes, PR/issue bodies, and comment templates with CLI helpers for rendering, validating, and posting.
  * Added "Mock Review HTML" and "HTML Review Pack" tools: generate self-contained HTML review artifacts for drafting and previewing reviews.

* **Documentation**
  * New guides on citation patterns, GitHub permalink usage, frontmatter schema, style conventions, examples, and README listing for the new skills.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->